### PR TITLE
Bugfix/me

### DIFF
--- a/R/fit_lasso.R
+++ b/R/fit_lasso.R
@@ -152,7 +152,7 @@ lasso_cv_search <- function (x, y, tau = 0.5,
                              foldid = NULL, nlambda = 100,
                              eps = 1e-04, init.lambda = 2,
                              parallel = T, coef.cutoff = 1e-5,
-                             thresh = 0,
+                             thresh = 0.01,
                              ...) {
   p <- dim(x)[2]
 
@@ -170,7 +170,7 @@ lasso_cv_search <- function (x, y, tau = 0.5,
                           weights = weights,
                           intercept = intercept, ...)
 
-    if (sum(abs(init_fit$coefficients[p_range])) <= thresh) {
+    if (mean(abs(init_fit$coefficients[p_range])) <= thresh) {
       searching <- FALSE
     } else {
       lambda_star <- lambda_star * 1.5
@@ -199,7 +199,7 @@ lasso_cv_search <- function (x, y, tau = 0.5,
                                      ...
                                      )
     }
-    if (sum(abs(coefficients(models[[lam_pos]])[p_range])) > thresh) {
+    if (mean(abs(coefficients(models[[lam_pos]])[p_range])) > thresh) {
       if(lam_pos > min_lambda_pos) {
         min_lambda_pos = lam_pos
       }

--- a/R/marginal_effects.R
+++ b/R/marginal_effects.R
@@ -6,18 +6,21 @@
 #' @importFrom stats sd
 #' @importFrom stats quantile
 bin_along_range <- function(x, size = NA, trim = 0.01) {
-  assertthat::assert_that(is.numeric(x))
-  assertthat::assert_that(all(!is.na(x)))
+  if(length(setdiff(x, c(0,1))) == 0) {
+    return(c(0, 1))
+  } else {
+    assertthat::assert_that(is.numeric(x))
+    assertthat::assert_that(all(!is.na(x)))
 
-  max_x <- quantile(x, 1 - trim)
-  min_x <- quantile(x, trim)
+    max_x <- quantile(x, 1 - trim)
+    min_x <- quantile(x, trim)
 
-  # slightly arbitrary, but w/e
-  if(is.na(size)) {
-    size = sd(x)/3
+    # slightly arbitrary, but w/e
+    if(is.na(size)) {
+      size = sd(x)/3
+    }
+    seq(min_x, max_x, by = size)
   }
-
-  seq(min_x, max_x, by = size)
 }
 
 #' Computes means for various slices of a regression_spec by betas product.
@@ -102,22 +105,16 @@ get_marginal_effects = function(qreg_coeffs,
 
 #' Get marginal effects at a set of levels for the covariates
 #' @param fit A fitted model from the `qs` function
-#' @param data optional data.frame that specifies level of data to calculate
+#' @param X model matrix that specifies level of data to calculate
 #' marginal effects
 #' @export
 #' @details A simple function which returns
 #' marginal effects for a given level of the dataset.
-me <- function(fit, data) {
-  ff = stats::as.formula(fit$specs$formula)
-  tt <- stats::terms(ff, data = data)
-  tt <- stats::delete.response(tt)
-  X <- stats::model.matrix(tt,
-                           data = data)
+me <- function(fit, X) {
 
-  if(get_intercept(data) > 0 | "(Intercept)" %in% colnames(data)) {
-    X <- X[,-1]
+  if(!is.matrix(X)) {
+    X <- as.matrix(X)
   }
-
   jstar <- fit$specs$jstar
 
   reg_coefs <- t(coef(fit))
@@ -160,15 +157,17 @@ me_by_variable <- function(fit, type, variable,
     X = stats::model.matrix(stats::as.formula(fit$specs$formula),
                               data = fit$specs$X)
 
+  } else {
+    X <- data
   }
 
   if (type == "mea") {
     data <- data.frame(t(colMeans(X)))
-    vardata <- mean(fit$specs$X[[variable]])
+    vardata <- mean(X[,variable])
   } else if (type == "varying") {
-    data <- data.frame(t(colMeans(X)))
+    data <- t(colMeans(X))
 
-    var <- fit$specs$X[[variable]]
+    var <- X[,variable]
     if(is.numeric(var)) {
       vardata <- bin_along_range(var)
     } else {
@@ -182,7 +181,7 @@ me_by_variable <- function(fit, type, variable,
     data[[variable]] <- vardata
 
   } else if (type == "ame") {
-    vardata <- mean(fit$specs$X[[variable]])
+    vardata <- mean(X[,variable])
     data <- as.data.frame(X)
   } else {
     stop("Type must be one of:\n",
@@ -195,12 +194,12 @@ me_by_variable <- function(fit, type, variable,
   if(type != "ame") {
 
     for(i in 1:length(data[[variable]])) {
-      this_level_me <- me(fit, data = data[i,])
+      this_level_me <- me(fit, X = data[i,])
       var_me[i,] <- this_level_me[which(rownames(this_level_me) == variable),]
     }
 
   } else {
-    var_me <- me(fit, data = data)
+    var_me <- me(fit, X = data)
     var_me <- var_me[which(rownames(var_me) == variable),]
     var_me <- matrix(var_me, ncol = length(var_me))
   }
@@ -241,13 +240,15 @@ marginal_effects <- function(fit,
                              size = NA,
                              trim = 0.05) {
 
-  d = stats::model.matrix(fit$specs$formula, data = fit$specs$X)
+  if(anyNA(data) & length(data) == 1) {
+    data = stats::model.matrix(fit$specs$formula, data = fit$specs$X)
+  }
   if(variable == "all") {
-    variable <- setdiff(colnames(d), "(Intercept)")
+    variable <- setdiff(colnames(data), "(Intercept)")
   }
 
   all_me <- lapply(variable,
-                   function(v, d) {
+                   function(v) {
                      me_by_variable(fit, type,
                                     v, data,
                                     size, trim)
@@ -257,7 +258,7 @@ marginal_effects <- function(fit,
   attr(all_me, "jstar") <- fit$specs$jstar
 
   ff = stats::as.formula(fit$specs$formula)
-  attr(all_me, "outcome") <- all.vars(ff)[attr(stats::terms(ff, data = d),
+  attr(all_me, "outcome") <- all.vars(ff)[attr(stats::terms(ff, data = data),
                                                       "response")]
 
   attr(all_me, "type") <- type

--- a/R/marginal_effects.R
+++ b/R/marginal_effects.R
@@ -114,6 +114,10 @@ me <- function(fit, data) {
   X <- stats::model.matrix(tt,
                            data = data)
 
+  if(get_intercept(data) > 0 | "(Intercept)" %in% colnames(data)) {
+    X <- X[,-1]
+  }
+
   jstar <- fit$specs$jstar
 
   reg_coefs <- t(coef(fit))
@@ -237,9 +241,8 @@ marginal_effects <- function(fit,
                              size = NA,
                              trim = 0.05) {
 
+  d = stats::model.matrix(fit$specs$formula, data = fit$specs$X)
   if(variable == "all") {
-
-    d = stats::model.matrix(fit$specs$formula, data = fit$specs$X)
     variable <- setdiff(colnames(d), "(Intercept)")
   }
 
@@ -254,7 +257,7 @@ marginal_effects <- function(fit,
   attr(all_me, "jstar") <- fit$specs$jstar
 
   ff = stats::as.formula(fit$specs$formula)
-  attr(all_me, "outcome") <- all.vars(ff)[attr(stats::terms(ff),
+  attr(all_me, "outcome") <- all.vars(ff)[attr(stats::terms(ff, data = d),
                                                       "response")]
 
   attr(all_me, "type") <- type

--- a/man/lasso_cv_search.Rd
+++ b/man/lasso_cv_search.Rd
@@ -18,7 +18,7 @@ lasso_cv_search(
   init.lambda = 2,
   parallel = T,
   coef.cutoff = 1e-05,
-  thresh = 0,
+  thresh = 0.01,
   ...
 )
 }

--- a/man/me.Rd
+++ b/man/me.Rd
@@ -4,12 +4,12 @@
 \alias{me}
 \title{Get marginal effects at a set of levels for the covariates}
 \usage{
-me(fit, data)
+me(fit, X)
 }
 \arguments{
 \item{fit}{A fitted model from the \code{qs} function}
 
-\item{data}{optional data.frame that specifies level of data to calculate
+\item{X}{model matrix that specifies level of data to calculate
 marginal effects}
 }
 \description{

--- a/tests/testthat/test_error_printing_util.R
+++ b/tests/testthat/test_error_printing_util.R
@@ -1,4 +1,3 @@
-context("Test utility for printing quantile regression warnings")
 
 testthat::test_that("error printing utility works for quantreg_spacing", {
   testthat::expect_warning(printWarnings(list(ierr="test", it = 100)))

--- a/tests/testthat/test_marginal_effects.R
+++ b/tests/testthat/test_marginal_effects.R
@@ -1,8 +1,9 @@
-context("Test marginal effects")
 
 fit1 <- qs(mpg ~ cyl, data = mtcars, calc_se = F)
 fit2 <- qs(mpg ~ cyl + hp, data = mtcars, calc_se = F)
 fit3 <- qs(mpg ~ factor(cyl), data = mtcars, calc_se = F)
+fit4 <- qs(peri ~ ., data = lapply(rock, function(x) as.numeric(scale(x))),
+           algorithm = "br", calc_se = F)
 
 testthat::test_that("Marginal Effects Run OK",{
   testthat::expect_equal(length(marginal_effects(fit1)), 1)
@@ -10,4 +11,6 @@ testthat::test_that("Marginal Effects Run OK",{
   testthat::expect_equal(attr(marginal_effects(fit1), "type"), "ame")
   testthat::expect_equal(nrow(marginal_effects(fit1)[[1]]), 1)
   testthat::expect_gt(nrow(marginal_effects(fit1, type = "varying")[[1]]), 1)
+  testthat::expect_equal(length(marginal_effects(fit4)), ncol(rock) - 1)
+  testthat::expect_equal(nrow(marginal_effects(fit3, type = "varying")[[1]]), 2)
 })

--- a/tests/testthat/test_qs.R
+++ b/tests/testthat/test_qs.R
@@ -1,10 +1,12 @@
-context("Tests that qs & distributional_effects work.")
 
 set.seed(100)
 setCores(1)
 
-x = matrix(rnorm(10000), ncol = 2)
+x = matrix(rnorm(100000), ncol = 100)
 y = 1 + 2 * x[,1] - 0.4 * x[,2] + rnorm(nrow(x)) * ( x[,1]) * 4 + rnorm(nrow(x)) * ( x[,2]) *3
+
+
+
 
 test_data = data.frame(y = y, x)
 
@@ -13,7 +15,6 @@ fit <- qs(y ~ X1 + X2, data = test_data,
 
 fit_sparse <- qs(y ~ X1 + X2, data = test_data,
           algorithm = "agd_sparse", parallel = F)
-
 
 de <- distributional_effects(fit)
 de_mat <- distributional_effects(fit, newdata = tail(test_data, 5))

--- a/tests/testthat/test_quantreg_spacing.R
+++ b/tests/testthat/test_quantreg_spacing.R
@@ -1,5 +1,3 @@
-context("Test Quantile Regression Algorithm Interface")
-
 X <- stats::model.matrix(mpg ~ cyl, data = mtcars)
 y <- stats::model.response(stats::model.frame(mpg ~ cyl, data = mtcars),
                              type = "numeric")

--- a/tests/testthat/test_standard_errors.R
+++ b/tests/testthat/test_standard_errors.R
@@ -1,4 +1,3 @@
-context("Test standard errors")
 
 # these will all generate warnings, ignore it for now
 suppressWarnings({


### PR DESCRIPTION
Fix marginal effects interface, which previously had bug involving multiple intercept columns when `~.` is in the formula. Also adjust how we get the "response" variable to fix bug involving same problem.